### PR TITLE
feat(pip): PiP ウィンドウのサイズを Canvas のアスペクト比に合わせる

### DIFF
--- a/entrypoints/background/pip.ts
+++ b/entrypoints/background/pip.ts
@@ -25,10 +25,24 @@ export const openPictureInPicture = async (tab: Tabs.Tab | undefined) => {
 				return;
 			}
 
+			// Canvas と同じアスペクト比 (16:9) になるよう PiP ウィンドウのサイズを計算する
+			const aspectRatio =
+				canvas.width > 0 && canvas.height > 0
+					? canvas.width / canvas.height
+					: 16 / 9;
+			// 画面の 1/3 程度を目安にしつつ、小さくなりすぎないようにする
+			const maxWidth = Math.max(480, Math.round(window.screen.availWidth / 3));
+			const maxHeight = Math.max(
+				270,
+				Math.round(window.screen.availHeight / 3),
+			);
+			const width = Math.round(Math.min(maxWidth, maxHeight * aspectRatio));
+			const height = Math.round(width / aspectRatio);
+
 			// @ts-expect-error documentPictureInPicture is not defined
 			const pipWindow = (await documentPictureInPicture.requestWindow({
-				width: 360,
-				height: 270,
+				width,
+				height,
 			})) as typeof window;
 
 			// スタイルを指定


### PR DESCRIPTION
## 概要

Document Picture-in-Picture API の `requestWindow()` に渡すサイズが `360x270`（4:3）固定だったため、16:9 のシャニマスの Canvas を表示すると上下に黒帯が出ていました。Canvas のアスペクト比からウィンドウサイズを計算するように変更します。

## 変更内容

`entrypoints/background/pip.ts`

```ts
const aspectRatio =
  canvas.width > 0 && canvas.height > 0 ? canvas.width / canvas.height : 16 / 9;
const maxWidth = Math.max(480, Math.round(window.screen.availWidth / 3));
const maxHeight = Math.max(270, Math.round(window.screen.availHeight / 3));
const width = Math.round(Math.min(maxWidth, maxHeight * aspectRatio));
const height = Math.round(width / aspectRatio);
```

- 比率はハードコードせず Canvas の実サイズから算出（サイズが 0 のときのみ 16:9 にフォールバック）
- 画面のおよそ 1/3 を目安にしつつ、`maxHeight * aspectRatio` で縦方向にも収まるように抑制。1920x1080 のディスプレイなら `640x360`
- 下限は `480x270`。小さい画面でもウィンドウが潰れないように

Document PiP 非対応環境での `video.requestPictureInPicture()` へのフォールバックは変更していません。

## 確認事項

- `pnpm build` が通ることを確認済み
- Biome の format / lint 済み（pre-commit フックも通過）
- ブラウザでの実表示は未確認です

---
_Generated by [Claude Code](https://claude.ai/code/session_011sUVjio9hRnfXVfpZBwKrn)_